### PR TITLE
introduce polyfills message for old browsers

### DIFF
--- a/dist/0-configuration.html
+++ b/dist/0-configuration.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -649,6 +668,27 @@
 <script data-config>
     var tf = new TableFilter('demo');
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/advanced-grid-editable.html
+++ b/dist/advanced-grid-editable.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13314,6 +13333,27 @@ ezEditTable</a>
 
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/advanced-grid-selection.html
+++ b/dist/advanced-grid-selection.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13270,6 +13289,27 @@ ezEditTable</a>
 
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/alphabetical-pager.html
+++ b/dist/alphabetical-pager.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -1985,6 +2004,27 @@
     tf.init();
     // keep reference of selected letter element
     tf.selectedLetter = null;
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/alternating-rows.html
+++ b/dist/alternating-rows.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -278,6 +297,27 @@
         alternate_rows: true
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/auto-filter.html
+++ b/dist/auto-filter.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -663,6 +682,27 @@
     };
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/case-sensitive.html
+++ b/dist/case-sensitive.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -283,6 +302,27 @@
         case_sensitive: true
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/column-calculations-api.html
+++ b/dist/column-calculations-api.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -841,6 +860,27 @@
         // display result
         document.getElementById(labelId).innerHTML = result.toFixed(2);
     }
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/column-calculations.html
+++ b/dist/column-calculations.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -1206,6 +1225,27 @@
         }
     );
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/column-widths.html
+++ b/dist/column-widths.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -283,6 +302,27 @@
         col_widths: ['200px', '200px', '160px', '105px', '105px']
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/columns-visibility.html
+++ b/dist/columns-visibility.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -2842,6 +2861,27 @@
     };
     var tf = new TableFilter('demo', tfConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/conditional-cell-formatting.html
+++ b/dist/conditional-cell-formatting.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13227,6 +13246,27 @@
             cell.style.backgroundColor = '#cfff33';
         }
     }
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/custom-checkbox-selection.html
+++ b/dist/custom-checkbox-selection.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -911,6 +930,27 @@
       return null;
     }
 
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/custom-filter-options.html
+++ b/dist/custom-filter-options.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13219,6 +13238,27 @@
     };
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/custom-filtering.html
+++ b/dist/custom-filtering.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -701,6 +720,27 @@ var tfConfig = {
 };
 var tf = new TableFilter('demo', tfConfig);
 tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/data-types.html
+++ b/dist/data-types.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -1209,6 +1228,27 @@
 
     var tf2 = new TableFilter('demo', tf2Config);
     tf2.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/deep-linking.html
+++ b/dist/deep-linking.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13201,6 +13220,27 @@
     };
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/dynamic-external-filters.html
+++ b/dist/dynamic-external-filters.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -791,6 +810,27 @@
       tf.setFilterValue(2, values);
       tf.filter();
     }
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/exact-match-by-column.html
+++ b/dist/exact-match-by-column.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 

--- a/dist/exact-match.html
+++ b/dist/exact-match.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -283,6 +302,27 @@
         exact_match: true
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/examples.html
+++ b/dist/examples.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 

--- a/dist/extension-run-time.html
+++ b/dist/extension-run-time.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -2025,6 +2044,27 @@
     }
 
 
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/external-filter-operators.html
+++ b/dist/external-filter-operators.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13272,6 +13291,27 @@ var tfConfig = {
         }
     );
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/external-filters.html
+++ b/dist/external-filters.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -759,6 +778,27 @@
 </script>
 
 <p class="clearfix"></p>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
+</script>
 
 <hr>
 <ul class="nav nav-pills">

--- a/dist/external-toolbar.html
+++ b/dist/external-toolbar.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13212,6 +13231,27 @@
     };
     var tf = new TableFilter(document.querySelector('#demo'), tfConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/extract-data-apis.html
+++ b/dist/extract-data-apis.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -868,6 +887,27 @@
 </script>
 
 <p class="clearfix"></p>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
+</script>
 
 <hr>
 <ul class="nav nav-pills">

--- a/dist/features-no-configuration.html
+++ b/dist/features-no-configuration.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -1971,6 +1990,27 @@
 
     tf.init();
 
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/filter-images.html
+++ b/dist/filter-images.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -615,6 +634,27 @@ var tfConfig = {
 };
 var tf = new TableFilter('demo', 2, tfConfig);
 tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/filter-types.html
+++ b/dist/filter-types.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -663,6 +682,27 @@
     };
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/filters-visibility-external-toggle.html
+++ b/dist/filters-visibility-external-toggle.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -2830,6 +2849,27 @@
     };
     var tf = new TableFilter('demo', tfConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/filters-visibility.html
+++ b/dist/filters-visibility.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -2821,6 +2840,27 @@
     };
     var tf = new TableFilter('demo', tfConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/grid-layout-custom-css.html
+++ b/dist/grid-layout-custom-css.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -807,6 +826,27 @@
         tfConfig
     );
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/grid-layout.html
+++ b/dist/grid-layout.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13206,6 +13225,27 @@
     };
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/grouped-headers.html
+++ b/dist/grouped-headers.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -9532,6 +9551,27 @@
 </script>
 
 <p></p>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
+</script>
 
 <hr>
 <ul class="nav nav-pills">

--- a/dist/highlight-keywords.html
+++ b/dist/highlight-keywords.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -278,6 +297,27 @@
         highlight_keywords: true
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/ignore-diacritics-by-column.html
+++ b/dist/ignore-diacritics-by-column.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 

--- a/dist/ignore-diacritics.html
+++ b/dist/ignore-diacritics.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -260,6 +279,27 @@
         ignore_diacritics: true
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/index.html
+++ b/dist/index.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 

--- a/dist/linked-filters-greyed-out-options.html
+++ b/dist/linked-filters-greyed-out-options.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -2828,6 +2847,27 @@
     };
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/linked-filters.html
+++ b/dist/linked-filters.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -2827,6 +2846,27 @@
     };
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/load-filters-on-demand.html
+++ b/dist/load-filters-on-demand.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13188,6 +13207,27 @@
     };
     var tf = new TableFilter('demo', tfConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/multiple-state-types.html
+++ b/dist/multiple-state-types.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -696,6 +715,27 @@
 
     var tf = new TableFilter(document.querySelector('.table'), tfConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/no-filters.html
+++ b/dist/no-filters.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -278,6 +297,27 @@
         grid: false
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/no-headers.html
+++ b/dist/no-headers.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -278,6 +297,27 @@
         { base_path: 'tablefilter/' }
     );
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/no-results-message.html
+++ b/dist/no-results-message.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -282,6 +301,27 @@
         no_results_message: true
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/paging.html
+++ b/dist/paging.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13221,6 +13240,27 @@
         width:auto; display:block;
     }
 </style>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
+</script>
 
 <hr>
 <ul class="nav nav-pills">

--- a/dist/persistence.html
+++ b/dist/persistence.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -13242,6 +13261,27 @@
   following values: <code>'hash'</code>, <code>'local_storage'</code> and
   <code>'cookie'</code>.
 </div>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
+</script>
 
 <hr>
 <ul class="nav nav-pills">

--- a/dist/popup-filters.html
+++ b/dist/popup-filters.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -678,6 +697,27 @@
     };
     var tf = new TableFilter('demo', filtersConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/responsive-grid-layout.html
+++ b/dist/responsive-grid-layout.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -671,6 +690,27 @@
       }
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/responsive.html
+++ b/dist/responsive.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -657,6 +676,27 @@
       responsive: true
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/rows-always-visible.html
+++ b/dist/rows-always-visible.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -279,6 +298,27 @@
         exclude_rows: [2, 8]
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/setup-requirejs.html
+++ b/dist/setup-requirejs.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -291,6 +310,27 @@ requirejs(['./tablefilter/tablefilter'], function(mod) {
         tf.init();
     }
 );
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/setup-systemjs.html
+++ b/dist/setup-systemjs.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -290,6 +309,27 @@ System.import('./tablefilter/tablefilter').then(function(mod) {
     );
     tf.init();
 });
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/single-filter-exclude-cols.html
+++ b/dist/single-filter-exclude-cols.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -693,6 +712,27 @@
 
     var tf = new TableFilter(document.querySelector('.table'), tfConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/single-filter.html
+++ b/dist/single-filter.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -278,6 +297,27 @@
         single_filter: true
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/sort-columns-external-command.html
+++ b/dist/sort-columns-external-command.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -737,6 +756,27 @@
         tfConfig
     );
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/sort-custom-type.html
+++ b/dist/sort-custom-type.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -523,6 +542,27 @@
         tfConfig
     );
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/sort.html
+++ b/dist/sort.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -585,6 +604,27 @@ var tfConfig = {
 };
 var tf = new TableFilter('data-types', tfConfig);
 tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/theme-roller.html
+++ b/dist/theme-roller.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -565,6 +584,27 @@
         var stylesheet = tf.getStylesheet('default');
         stylesheet.href = THEMES[name];
     }
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/toggle-features.html
+++ b/dist/toggle-features.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -808,6 +827,27 @@
 
     var tf = createTableFilter(true);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/using-bootstrap.html
+++ b/dist/using-bootstrap.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -704,6 +723,27 @@ enabled, follow the following steps to take advantage of Bootstrap styling:
 
     var tf = new TableFilter(document.querySelector('.table'), tfConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/using-material-design-lite.html
+++ b/dist/using-material-design-lite.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -722,6 +741,27 @@ styling:
 
     var tf = new TableFilter(document.querySelector('#demo'), tfConfig);
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/dist/watermark.html
+++ b/dist/watermark.html
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 
@@ -278,6 +297,27 @@
         watermark: ['City', 'City', 'Distance', 'Time', 'Time']
     });
     tf.init();
+</script>
+
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
 </script>
 
 <hr>

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -20,6 +20,25 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Polyfills for IE -->
+    <script>
+      var loadedPolyfills = (function (window, Function) {
+        var namedPolyfills = [];
+
+        if(!window.Promise) {
+          document.write('<script src="//unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js"><\/script>');
+          namedPolyfills.push('window.Promise');
+        }
+
+        if(!Function.name) {
+          document.write('<script src="//unpkg.com/function.name-polyfill@latest/Function.name.js"><\/script>');
+          namedPolyfills.push('Function.name');
+        }
+
+        return namedPolyfills;
+      })(window, Function)
+    </script>
   </head>
   <body>
 

--- a/src/templates/partials/code-tabs.hbs
+++ b/src/templates/partials/code-tabs.hbs
@@ -1,3 +1,4 @@
+{{> polyfills-message}}
 <hr>
 <ul class="nav nav-pills">
     <li class="active">

--- a/src/templates/partials/polyfills-message.hbs
+++ b/src/templates/partials/polyfills-message.hbs
@@ -1,0 +1,20 @@
+<script>
+  (function(loadedPolyfills, document) {
+    if(loadedPolyfills.indexOf('window.Promise') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Promise</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/es6-promise@3.2.1/dist/es6-promise.min.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+    if(loadedPolyfills.indexOf('Function.name') !== -1) {
+      var msg = '<br><div class="alert alert-danger" role="alert">'
+        + 'Your browser does not support <code>Function.name</code>.<br>'
+        + 'Use a polyfill to provide support for the missing language feature, eg:'
+        + '<pre>https://unpkg.com/function.name-polyfill@latest/Function.name.js</pre>'
+        + '</div>';
+        document.write(msg);
+    }
+  })(loadedPolyfills, document)
+</script>


### PR DESCRIPTION
Introduce `Promise` and `Function.Name` polyfills for old browsers.
Display a message with required polyfills.